### PR TITLE
Stop `changelog-notes` extractor at `<!-- scriv-end-here -->` marker

### DIFF
--- a/.ci/changelog-notes
+++ b/.ci/changelog-notes
@@ -24,8 +24,9 @@ def extract_notes(changelog: str, version: str) -> str | None:
 
     start = match.end() + 1  # skip past header line's newline
 
-    # The section ends at the next version header or ``<a id=`` anchor.
-    boundary = re.compile(r"^(?:## |<a id=)", re.MULTILINE)
+    # The section ends at the next version header, ``<a id=`` anchor, or
+    # trailing scriv marker.
+    boundary = re.compile(r"^(?:## |<a id=|<!-- scriv-end-here -->)", re.MULTILINE)
     end_match = boundary.search(changelog, start)
     raw = changelog[start : end_match.start()] if end_match else changelog[start:]
 


### PR DESCRIPTION
What changed
* `.ci/changelog-notes` boundary regex now also stops at `<!-- scriv-end-here -->`.

Why
* The extractor stopped at `## ` headers and `<a id=` anchors but not at the trailing scriv marker. Once scriv emits `<!-- scriv-end-here -->`, the extractor would silently include it in release notes.
* Port of the same fix already applied in `shellgenius`.

How to test
* Run `.ci/changelog-notes 0.3.0` — output should be unchanged (no `<!-- scriv-end-here -->` in current CHANGELOG).
* Create a test changelog with `<!-- scriv-end-here -->` after a version section and verify the extractor stops before it:
  ```
  echo -e "## 0.0.1\n\nFixed\n-----\n* Bug fix\n\n<!-- scriv-end-here -->\n\n## 0.0.0\n" > /tmp/test-cl.md
  .ci/changelog-notes 0.0.1 /tmp/test-cl.md
  # Should print only "### Fixed\n* Bug fix", without the scriv marker

Risk/comp notes
* Low risk — adds a stop condition; existing behavior unchanged for CHANGELOGs without the marker.

Changelog fragment: no (internal CI tool, no user-visible behavior change)