### PR TITLE
Make `chatgpt_request` compatible with OpenAI 2.x

### DIFF
--- a/.ci/changelog-notes
+++ b/.ci/changelog-notes
@@ -24,8 +24,9 @@ def extract_notes(changelog: str, version: str) -> str | None:
 
     start = match.end() + 1  # skip past header line's newline
 
-    # The section ends at the next version header or ``<a id=`` anchor.
-    boundary = re.compile(r"^(?:## |<a id=)", re.MULTILINE)
+    # The section ends at the next version header, ``<a id=`` anchor, or
+    # trailing scriv marker.
+    boundary = re.compile(r"^(?:## |<a id=|<!-- scriv-end-here -->)", re.MULTILINE)
     end_match = boundary.search(changelog, start)
     raw = changelog[start : end_match.start()] if end_match else changelog[start:]
 

--- a/changelog.d/openai-2x-compatibility.md
+++ b/changelog.d/openai-2x-compatibility.md
@@ -1,0 +1,3 @@
+Fixed
+-----
+* Widened the supported `openai` range to include 2.x and switched streaming requests to the public SDK interface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "click ~= 8.3",
     "httpx>=0.28.1",
-    "openai >= 1.66.0, <2.0",
+    "openai >= 1.66.0, <3.0",
     "tiktoken ~= 0.12",
     "urllib3 >= 2.6.3",
 ]

--- a/tests/test_gpt_integration_sdk_boundary.py
+++ b/tests/test_gpt_integration_sdk_boundary.py
@@ -1,0 +1,158 @@
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import RateLimitError
+
+from vocabmaster import gpt_integration
+
+
+class FakeStreamingResponse:
+    def __init__(self, events, final_response):
+        self._events = list(events)
+        self._final_response = final_response
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_response(self):
+        return self._final_response
+
+
+class FakeStreamingContext:
+    def __init__(self, stream_response=None, enter_error=None):
+        self._stream_response = stream_response
+        self._enter_error = enter_error
+
+    def __enter__(self):
+        if self._enter_error is not None:
+            raise self._enter_error
+        return self._stream_response
+
+    def __exit__(self, exc_type, exc, exc_tb):
+        return False
+
+
+def test_chatgpt_request_non_streaming_uses_response_output_text():
+    create_calls = []
+    response = SimpleNamespace(output_text="bonjour\thello\texample")
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            create_calls.append(kwargs)
+            return response
+
+    client = SimpleNamespace(responses=FakeResponses())
+
+    generated_text, response_time, raw_response = gpt_integration.chatgpt_request(
+        prompt=[{"role": "user", "content": "Translate bonjour"}],
+        stream=False,
+        client=client,
+    )
+
+    assert generated_text == response.output_text
+    assert response_time >= 0
+    assert raw_response is response
+    assert create_calls == [
+        {
+            "input": [{"role": "user", "content": "Translate bonjour"}],
+            "model": gpt_integration.DEFAULT_MODEL,
+            "temperature": 0.7,
+            "stream": False,
+        }
+    ]
+
+
+def test_chatgpt_request_streaming_uses_public_stream_api_and_filters_output(capsys):
+    stream_calls = []
+    final_response = SimpleNamespace(
+        output_text="bonjour\tbon jour\thello\texample\nsalut\tsalut\thi\texample two\n"
+    )
+    stream_response = FakeStreamingResponse(
+        events=[
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_text.delta", delta="bonjour\tbon jour\t"),
+            SimpleNamespace(type="response.output_text.delta", delta="hello\texample\n"),
+            SimpleNamespace(type="response.output_text.delta", delta="salut\tsalut\thi\t"),
+            SimpleNamespace(type="response.output_text.delta", delta="example two\n"),
+        ],
+        final_response=final_response,
+    )
+
+    class FakeResponses:
+        def stream(self, **kwargs):
+            stream_calls.append(kwargs)
+            return FakeStreamingContext(stream_response=stream_response)
+
+    client = SimpleNamespace(responses=FakeResponses())
+
+    generated_text, response_time, raw_response = gpt_integration.chatgpt_request(
+        prompt=[{"role": "user", "content": "Translate bonjour and salut"}],
+        stream=True,
+        client=client,
+    )
+
+    captured = capsys.readouterr()
+
+    assert generated_text == final_response.output_text
+    assert response_time >= 0
+    assert raw_response is final_response
+    assert captured.out == "bonjour\thello\texample\nsalut\thi\texample two\n\n"
+    assert stream_calls == [
+        {
+            "input": [{"role": "user", "content": "Translate bonjour and salut"}],
+            "model": gpt_integration.DEFAULT_MODEL,
+            "temperature": 0.7,
+        }
+    ]
+
+
+def test_chatgpt_request_streaming_falls_back_to_final_output_text(capsys):
+    final_response = SimpleNamespace(output_text="bonjour\tbon jour\thello\texample\n")
+    stream_response = FakeStreamingResponse(
+        events=[SimpleNamespace(type="response.completed")],
+        final_response=final_response,
+    )
+
+    class FakeResponses:
+        def stream(self, **kwargs):
+            return FakeStreamingContext(stream_response=stream_response)
+
+    client = SimpleNamespace(responses=FakeResponses())
+
+    generated_text, _response_time, raw_response = gpt_integration.chatgpt_request(
+        prompt=[{"role": "user", "content": "Translate bonjour"}],
+        stream=True,
+        client=client,
+    )
+
+    captured = capsys.readouterr()
+
+    assert generated_text == final_response.output_text
+    assert raw_response is final_response
+    assert captured.out == "bonjour\thello\texample\n\n"
+
+
+def test_chatgpt_request_streaming_propagates_public_status_errors():
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(429, request=request)
+    rate_limit_error = RateLimitError("Too many requests", response=response, body=None)
+
+    class FakeResponses:
+        def stream(self, **kwargs):
+            return FakeStreamingContext(enter_error=rate_limit_error)
+
+    def forbidden_private_helper(_response):
+        raise AssertionError("private OpenAI helper should not be used")
+
+    client = SimpleNamespace(
+        responses=FakeResponses(),
+        _make_status_error_from_response=forbidden_private_helper,
+    )
+
+    with pytest.raises(RateLimitError):
+        gpt_integration.chatgpt_request(
+            prompt=[{"role": "user", "content": "Translate bonjour"}],
+            stream=True,
+            client=client,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.109.1"
+version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -470,9 +470,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/fe/64b3d035780b3188f86c4f6f1bc202e7bb74757ef028802112273b9dcacf/openai-2.31.0.tar.gz", hash = "sha256:43ca59a88fc973ad1848d86b98d7fac207e265ebbd1828b5e4bdfc85f79427a5", size = 684772, upload-time = "2026-04-08T21:01:41.797Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bc/a8f7c3aa03452fedbb9af8be83e959adba96a6b4a35e416faffcc959c568/openai-2.31.0-py3-none-any.whl", hash = "sha256:44e1344d87e56a493d649b17e2fac519d1368cbb0745f59f1957c4c26de50a0a", size = 1153479, upload-time = "2026-04-08T21:01:39.217Z" },
 ]
 
 [[package]]
@@ -981,7 +981,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = "~=8.3" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "openai", specifier = ">=1.66.0,<2.0" },
+    { name = "openai", specifier = ">=1.66.0,<3.0" },
     { name = "tiktoken", specifier = "~=0.12" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]

--- a/vocabmaster/gpt_integration.py
+++ b/vocabmaster/gpt_integration.py
@@ -3,7 +3,6 @@ import json
 import os
 import time
 
-import httpx
 import tiktoken
 from openai import OpenAI
 
@@ -167,51 +166,31 @@ def chatgpt_request(
     stream_enabled = bool(stream)
 
     if stream_enabled:
-        collected_chunks = []
         collected_messages = []
         streaming_state = {"line_buffer": ""}
+        final_response = None
 
-        with client.responses.with_streaming_response.create(
+        with client.responses.stream(
             input=prompt,
             model=model,
             # max_output_tokens=max_tokens,
             temperature=temperature,
-            stream=True,
-        ) as response:
-            try:
-                response.http_response.raise_for_status()
-            except httpx.HTTPStatusError as error:
-                if not error.response.is_closed:
-                    error.response.read()
-                raise client._make_status_error_from_response(error.response) from None
-            for line in response.iter_lines():
-                if not line:
-                    continue
-                if isinstance(line, bytes):
-                    line = line.decode("utf-8", errors="replace")
-                if not line.startswith("data:"):
-                    continue
-                payload = line[len("data:") :].strip()
-                if payload == "[DONE]":
-                    break
-                try:
-                    event = json.loads(payload)
-                except json.JSONDecodeError:
-                    continue
-                collected_chunks.append(event)
-                event_type = event.get("type")
-                if event_type == "response.output_text.delta":
-                    delta = event.get("delta", "")
+        ) as stream_response:
+            for event in stream_response:
+                if getattr(event, "type", None) == "response.output_text.delta":
+                    delta = getattr(event, "delta", "")
                     if delta:
                         collected_messages.append(delta)
                         filtered_content = filter_streaming_tsv(delta, streaming_state)
                         print(filtered_content, end="")
-                elif event_type == "response.output_text.done" and not collected_messages:
-                    text = event.get("text", "")
-                    if text:
-                        collected_messages.append(text)
-                        filtered_content = filter_streaming_tsv(text, streaming_state)
-                        print(filtered_content, end="")
+            final_response = stream_response.get_final_response()
+
+        generated_text = "".join(collected_messages)
+        if not generated_text:
+            generated_text = final_response.output_text
+            if generated_text:
+                filtered_content = filter_streaming_tsv(generated_text, streaming_state)
+                print(filtered_content, end="")
         tail = filter_streaming_tsv("", streaming_state, final=True)
         if tail:
             print(tail, end="")
@@ -219,8 +198,7 @@ def chatgpt_request(
 
         # Save the time delay and text received
         response_time = (time.monotonic_ns() - start_time) / 1e9
-        generated_text = "".join(collected_messages)
-        response = collected_chunks
+        response = final_response
 
     else:
         # Extract and save the generated response


### PR DESCRIPTION
## What changed
* Updated `vocabmaster/gpt_integration.py` so `chatgpt_request` uses the OpenAI Responses 2.x public interfaces: `client.responses.stream(...)` for streaming and `client.responses.create(...)` for non-streaming.
* Removed reliance on private SDK error helpers and kept streaming TSV filtering behavior.
* Added regression coverage in `tests/test_gpt_integration_sdk_boundary.py` for streaming/non-streaming behavior, streamed delta handling, fallback to final output text, and public `RateLimitError` propagation.
* Widened the `openai` dependency constraint in `pyproject.toml` and refreshed `uv.lock` accordingly.
* Added changelog fragment `changelog.d/openai-2x-compatibility.md`.

## Why
* The previous integration path depended on OpenAI SDK 1.x behavior and private internals that are not stable in 2.x.
* This keeps the existing `vocabmaster` flow compatible with OpenAI 2.x while preserving current output behavior.

## How to test
* Automated:
* Run `gate` from the repository root.
* Functional/manual:
* Set `OPENAI_API_KEY` (or `~/.config/lmt/key.env`) with a valid key.
* Run `vocabmaster pairs add` and create a test pair.
* Run `vocabmaster add <word>` for one or more words in that pair.
* Run `vocabmaster translate` and verify TSV output still shows `original_word`, translations/definition field, and a single example sentence per row.
* Re-run `vocabmaster translate` with enough words to observe streamed output and confirm no SDK compatibility error is raised.

## Risk/comp notes
* Main compatibility risk is SDK event-shape drift on future OpenAI releases; tests pin current expected public event usage.
* Streaming path now depends on `response.output_text.delta` events; when absent, code falls back to `final_response.output_text`.

## Changelog fragment
* yes — user-visible compatibility fix documented in `changelog.d/openai-2x-compatibility.md`.